### PR TITLE
Update write-release-index for symlinks

### DIFF
--- a/compile.lisp
+++ b/compile.lisp
@@ -39,8 +39,9 @@ available-versions-url: ~a"
               (archive-md5 project)
               (source-sha1 project)
               (prefix project)
-              (remove-duplicates (loop for system in (systems project) collect (enough-namestring (file system)
-                                                                                                  (source-directory (project project))))
+              (remove-duplicates (loop for system in (systems project)
+                                       collect (enough-namestring (truename (file system))
+                                                                  (truename (source-directory (project project)))))
                                  :test #'string=)))))
 
 (defun write-system-index (release stream)


### PR DESCRIPTION
On some operating systems (FreeBSD) symllinks get resolved to absolute pathnames. This makes `enough-namestring` fail when the other pathname is still a relative pathname. To unsure that this works even for non-symllinks I used `truename` on both pathnames.

Discovered on IRC here (bit verbose so feel free to ignore) https://irclog.tymoon.eu/libera/%23clasp?around=1710448716#1710448716

The fix was discovered on the next log page.

@drmeister